### PR TITLE
entrypoint: hook scripts support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # ChangeLog
 
+## 0.5.0
+
+- hook scripts support
+
+## 0.4.0
+
+- CDKTF 0.20.11
+
 ## 0.3.0
 
 - CDKTF 0.20.9

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1733767867 AS prod
 
-LABEL konflux.additional-tags="cdktf-0.20.9-tf-1.6.6-py-3.11-v0.4.0"
+LABEL konflux.additional-tags="cdktf-0.20.11-tf-1.6.6-py-3.11-v0.5.0"
 
 USER 0
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,6 +35,42 @@ OUTPUT_FILE=${OUTPUT_FILE:-"/work/output.json"}
 CDKTF_OUT_DIR="$ER_OUTDIR/stacks/CDKTF"
 TERRAFORM_CMD="terraform -chdir=$CDKTF_OUT_DIR"
 
+function run_hook() {
+    local HOOK_NAME="$1"
+    shift
+    local HOOK_DIR="./hooks"
+    local HOOK_SCRIPT=""
+
+    # Possible extensions for the hook scripts
+    local EXTENSIONS=("sh" "py")
+
+    if [ ! -d "$HOOK_DIR" ]; then
+        # no hook directory
+        return 0
+    fi
+
+    # Search for a valid hook script
+    for EXT in "${EXTENSIONS[@]}"; do
+        if [ -x "${HOOK_DIR}/${HOOK_NAME}.${EXT}" ]; then
+            HOOK_SCRIPT="${HOOK_DIR}/${HOOK_NAME}.${EXT}"
+            break
+        fi
+    done
+
+    if [ -z "$HOOK_SCRIPT" ]; then
+        # no hook script
+        return 0
+    fi
+
+    # Export variables for hooks
+    export DRY_RUN
+
+    echo "Running hook: $HOOK_NAME"
+    "$HOOK_SCRIPT" "$@"
+}
+
+run_hook "pre_hook"
+
 # CDKTF init forces the provider re-download to calculate
 # Other platform provider SHAs. USing terraform to init the configuration avoids it
 # This shuold be reevaluated in the future.
@@ -43,28 +79,26 @@ cdktf synth --output "$ER_OUTDIR"
 $TERRAFORM_CMD init
 
 if [[ $ACTION == "Apply" ]]; then
-    if [[ $DRY_RUN == "True" ]]; then
-        $TERRAFORM_CMD plan -out=plan --lock=false
-        if [ -f "validate_plan.py" ]; then
-            $TERRAFORM_CMD show -json "$CDKTF_OUT_DIR"/plan > "$CDKTF_OUT_DIR"/plan.json
-            python3 validate_plan.py "$CDKTF_OUT_DIR"/plan.json
-        fi
-    elif [[ $DRY_RUN == "False" ]]; then
+    $TERRAFORM_CMD plan -out=plan --lock=false
+    $TERRAFORM_CMD show -json "$CDKTF_OUT_DIR"/plan > "$CDKTF_OUT_DIR"/plan.json
+    run_hook "validate_plan" "$CDKTF_OUT_DIR"/plan.json
+
+    if [[ $DRY_RUN == "False" ]]; then
         # cdktf apply isn't reliable for now, using terraform apply instead
-        $TERRAFORM_CMD apply -auto-approve
+        $TERRAFORM_CMD apply -auto-approve "$CDKTF_OUT_DIR"/plan
         $TERRAFORM_CMD output -json > "$OUTPUT_FILE"
-        if [ -f "post_checks.py" ]; then
-            python3 post_checks.py "$OUTPUT_FILE"
-        fi
+        run_hook "check_output" "$OUTPUT_FILE"
     fi
+    run_hook "post_apply" "$CDKTF_OUT_DIR"/plan.json
+
 elif [[ $ACTION == "Destroy" ]]; then
     if [[ $DRY_RUN == "True" ]]; then
         $TERRAFORM_CMD plan -out=plan -destroy --lock=false
-        if [ -f "validate_plan.py" ]; then
-            $TERRAFORM_CMD show -json "$CDKTF_OUT_DIR"/plan > "$CDKTF_OUT_DIR"/plan.json
-            python3 validate_plan.py "$CDKTF_OUT_DIR"/plan.json
-        fi
+        $TERRAFORM_CMD show -json "$CDKTF_OUT_DIR"/plan > "$CDKTF_OUT_DIR"/plan.json
+        run_hook "validate_plan" "$CDKTF_OUT_DIR"/plan.json
+
     elif [[ $DRY_RUN == "False" ]]; then
         $TERRAFORM_CMD destroy --auto-approve
     fi
+    run_hook "post_delete"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,6 +34,10 @@ export CDKTF_LOG_LEVEL=${CDKTF_LOG_LEVEL:-"warn"}
 OUTPUT_FILE=${OUTPUT_FILE:-"/work/output.json"}
 CDKTF_OUT_DIR="$ER_OUTDIR/stacks/CDKTF"
 TERRAFORM_CMD="terraform -chdir=$CDKTF_OUT_DIR"
+LOCK="-lock=true"
+if [[ $DRY_RUN == "True" ]]; then
+    LOCK="-lock=false"
+fi
 
 function run_hook() {
     local HOOK_NAME="$1"
@@ -79,7 +83,7 @@ cdktf synth --output "$ER_OUTDIR"
 $TERRAFORM_CMD init
 
 if [[ $ACTION == "Apply" ]]; then
-    $TERRAFORM_CMD plan -out=plan --lock=false
+    $TERRAFORM_CMD plan -out=plan "$LOCK"
     $TERRAFORM_CMD show -json "$CDKTF_OUT_DIR"/plan > "$CDKTF_OUT_DIR"/plan.json
     run_hook "validate_plan" "$CDKTF_OUT_DIR"/plan.json
 
@@ -93,7 +97,7 @@ if [[ $ACTION == "Apply" ]]; then
 
 elif [[ $ACTION == "Destroy" ]]; then
     if [[ $DRY_RUN == "True" ]]; then
-        $TERRAFORM_CMD plan -out=plan -destroy --lock=false
+        $TERRAFORM_CMD plan -out=plan -destroy "$LOCK"
         $TERRAFORM_CMD show -json "$CDKTF_OUT_DIR"/plan > "$CDKTF_OUT_DIR"/plan.json
         run_hook "validate_plan" "$CDKTF_OUT_DIR"/plan.json
 


### PR DESCRIPTION
Add more script hooks into `entrypoint.sh`. Hook scripts are provided by sub-image in `./hooks` directory and can be bash or python scripts. 


Breaking changes: 

* all hook scripts must be executable (`chmod +x ...`)
* all scripts must be moved in `./hooks` dir
* `post_check.py` must be renamed to `check_output.py`


Preparing work for [APPSRE-11432](https://issues.redhat.com/browse/APPSRE-11432)