### PR TITLE
refactor cdktf provider sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## 0.6.0
+
+- Python 3.12
+- `cdktf-provider-sync` downloads the Terraform providers based on the Python CDKTF packages in your `pyproject.toml`
+
 ## 0.5.0
 
 - hook scripts support

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,10 @@ ENV TF_VERSION="1.6.6" \
 COPY LICENSE /licenses/LICENSE
 
 # Install python
-RUN microdnf install -y python3.11 && \
-    update-alternatives --install /usr/bin/python3 python /usr/bin/python3.11 1
+RUN microdnf install -y python3.12 && \
+    update-alternatives --install /usr/bin/python3 python /usr/bin/python3.12 1 && \
+    microdnf clean all && \
+    rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 
 # Install nodejs and other dependencies
 RUN INSTALL_PKGS="make nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar which unzip" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1738643652@sha256:3902bab19972cd054fd08b2a4e08612ae7e68861ee5d9a5cf22d828f27e2f479 AS prod
 
-LABEL konflux.additional-tags="cdktf-0.20.11-tf-1.6.6-py-3.11-v0.5.0"
+LABEL konflux.additional-tags="cdktf-0.20.11-tf-1.6.6-py-3.12-v0.6.0"
 
 USER 0
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ test:
 	touch /tmp/test && rm /tmp/test
 
 	[ -f "entrypoint.sh" ]
+	[ -x "/usr/local/bin/cdktf-provider-sync" ]
 
 .PHONY: build
 build:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ test:
 	# test binaries are installed
 	cdktf --version
 	terraform --version
+	python3 --version
 
 	# test /tmp is empty
 	[ -z "$(shell ls -A /tmp)" ]

--- a/cdktf-provider-sync
+++ b/cdktf-provider-sync
@@ -1,23 +1,40 @@
 #!/bin/bash
+# shellcheck disable=SC1091
+
 set -e
 
-if [ -z "$1" ]; then
-    echo "Usage: $0 <destination-directory>"
+if [ ! -f "pyproject.toml" ]; then
+    echo "pyproject.toml does not exist"
     exit 1
 fi
 
-if [ ! -f "cdktf.json" ]; then
-    echo "cdktf.json does not exist"
-    exit 1
-fi
+# activate the virtual environment
+source .venv/bin/activate
 
-cdktf get --parallelism 1 --output "$1"
+# cdktf uses pip to get the installed CDKTF version
+pip --version > /dev/null || (echo "pip not found. Please add it to your pyproject.toml" && exit 1)
 
-for i in "$1"/*; do
-    if [ ! -d "$i" ]; then
-        continue
-    fi
-    dest=$1/cdktf_cdktf_provider_$(basename "$i")
-    echo "Moving $i to $dest"
-    mv "$i" "$dest"
-done
+TF_TMP=$(mktemp -d)
+
+# generate terraform provider config
+cdktf provider list --json | python3 -c '
+import sys, json
+
+data = json.load(sys.stdin)
+
+providers = {
+    p["providerName"]: {"version": p["providerVersion"]}
+    for k in ["local", "prebuilt"]
+    for p in data.get(k, [])
+}
+
+result = {"terraform": {"required_providers": providers}}
+
+print(json.dumps(result, indent=2))
+' > "$TF_TMP/main.tf.json"
+
+# download all required providers to $TF_PLUGIN_CACHE_DIR
+terraform -chdir="$TF_TMP" init
+
+# cleanup
+rm -rf "$TF_TMP"

--- a/cdktf-provider-sync
+++ b/cdktf-provider-sync
@@ -11,7 +11,7 @@ fi
 # activate the virtual environment
 source .venv/bin/activate
 
-# cdktf uses pip to get the installed CDKTF version
+# cdktf uses pip to get the installed CDKTF provider version
 pip --version > /dev/null || (echo "pip not found. Please add it to your pyproject.toml" && exit 1)
 
 TF_TMP=$(mktemp -d)


### PR DESCRIPTION
`cdktf-provider-sync` no longer generates the Python CDKTF modules. Instead, it downloads them based on the specified CDKTF Python packages. This significantly reduces the sub-image build time.  

Breaking changes:
* sub-images must add the CDKTF Python providers and `pip` to `pyproject.toml` 
* The `cdktf.json` must have an empty terraform providers list `"terraformProviders": []`
* Python 3.12

See it in action: https://github.com/app-sre/er-aws-elasticache/pull/122

Ticket: [APPSRE-11503](https://issues.redhat.com/browse/APPSRE-11503)
